### PR TITLE
Add snbt::parse_and_size

### DIFF
--- a/src/snbt.rs
+++ b/src/snbt.rs
@@ -44,6 +44,14 @@ use std::{
 /// );
 /// ```
 pub fn parse<T: AsRef<str> + ?Sized>(string_nbt: &T) -> Result<NbtCompound, SnbtError> {
+    parse_and_size(string_nbt).map(|(_, tag)| tag)
+}
+
+/// Parses the given string just like [`parse`], but also returns the amount of parsed characters.
+///
+pub fn parse_and_size<T: AsRef<str> + ?Sized>(
+    string_nbt: &T,
+) -> Result<(usize, NbtCompound), SnbtError> {
     let mut tokens = Lexer::new(string_nbt.as_ref());
     let open_curly = tokens.assert_next(Token::OpenCurly)?;
     parse_compound_tag(&mut tokens, &open_curly)
@@ -68,7 +76,7 @@ fn parse_value(tokens: &mut Lexer<'_>, token: Option<TokenData>) -> Result<NbtTa
                 token: Token::OpenCurly,
                 ..
             },
-        ) => parse_compound_tag(tokens, &td).map(Into::into),
+        ) => parse_compound_tag(tokens, &td).map(|(_, tag)| tag.into()),
 
         // Open square brace indicates that some kind of list is present
         #[rustfmt::skip]
@@ -274,7 +282,7 @@ fn parse_tag_list(tokens: &mut Lexer<'_>, first_element: NbtTag) -> Result<NbtLi
 fn parse_compound_tag<'a>(
     tokens: &mut Lexer<'a>,
     open_curly: &TokenData,
-) -> Result<NbtCompound, SnbtError> {
+) -> Result<(usize, NbtCompound), SnbtError> {
     let mut compound = NbtCompound::new();
     // Zero is used as a niche value so the first iteration of the loop runs correctly
     let mut comma: Option<usize> = Some(0);
@@ -288,7 +296,7 @@ fn parse_compound_tag<'a>(
             }) => {
                 match comma {
                     // First loop iteration or no comma
-                    Some(0) | None => return Ok(compound),
+                    Some(0) | None => return Ok((tokens.index, compound)),
                     // Later iteration with a trailing comma
                     Some(index) => return Err(SnbtError::trailing_comma(tokens.raw, index)),
                 }

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -13,7 +13,7 @@ fn big_test() {
     let result = snbt::parse(BIG_SNBT);
     assert!(result.is_ok());
     let result = result.unwrap();
-    let inner = &result
+    let inner = result
         .get::<_, &NbtCompound>("Riding")
         .unwrap()
         .get::<_, &NbtCompound>("Riding")
@@ -23,8 +23,14 @@ fn big_test() {
         .get::<_, &NbtCompound>("TileEntityData")
         .unwrap()
         .get::<_, &str>("Command")
-        .unwrap()[32 ..];
-    assert!(snbt::parse(inner).is_ok());
+        .unwrap()[32 ..]
+        .to_string()
+        + " and some garbage";
+    assert!(snbt::parse(&inner).is_ok());
+    assert_eq!(
+        snbt::parse_and_size(&inner).unwrap().0,
+        inner.len() - " and some garbage".len()
+    );
 }
 
 #[test]

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -28,7 +28,7 @@ fn big_test() {
         + " and some garbage";
     assert!(snbt::parse(&inner).is_ok());
     assert_eq!(
-        snbt::parse_and_size(&inner).unwrap().0,
+        snbt::parse_and_size(&inner).unwrap().1,
         inner.len() - " and some garbage".len()
     );
 }


### PR DESCRIPTION
`parse_and_size` returns the parsing result and a number of characters consumed. It can be useful when trying to find a leftover of a string (characters after ending `}`)