### PR TITLE
Fix SnbtError::segment index out of bounds

### DIFF
--- a/src/snbt.rs
+++ b/src/snbt.rs
@@ -1013,12 +1013,13 @@ impl SnbtError {
             .nth(before.saturating_sub(1))
             .map(|(index, _)| index)
             .unwrap_or(0);
-        let end = index
+        let end = (index
             + input[index ..]
                 .char_indices()
                 .nth(char_width.min(20) + after)
                 .map(|(index, _)| index)
-                .unwrap_or(input.len());
+                .unwrap_or(input.len()))
+        .min(input.len());
         input[start .. end].to_owned()
     }
 }


### PR DESCRIPTION
{"a:b} was panicking because it's `index` + `*char_index* (input[index ..].char_indices()) ...`, and in this example `index` is 1 and `*char_index*` is input.len() because of its `unwrap_or`, and `1 + input.len()` was producing an index out of bounds error. Now the whole sum of `index` + `*char_index*` is compared to input.len() to prevent this type of error.