### PR TITLE
Fix incorrect SNBT string and key quoting

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -187,6 +187,18 @@ impl NbtTag {
     /// non-standard characters.
     #[inline]
     pub fn should_quote(string: &str) -> bool {
+        if let Some(first) = string.chars().next() {
+            if first.is_whitespace() || first.is_ascii_digit() {
+                return true;
+            }
+        }
+
+        if let Some(last) = string.chars().next_back() {
+            if last.is_whitespace() {
+                return true;
+            }
+        }
+
         for ch in string.chars() {
             if ch == ':'
                 || ch == ','

--- a/tests/assets/mod.rs
+++ b/tests/assets/mod.rs
@@ -104,6 +104,9 @@ pub static SNBT_EDGE_CASES_VALIDATE: Lazy<NbtCompound> = Lazy::new(|| {
         "redundant": "quotes",
         "more_redundant": "quotes",
         "escape sequences": "\'a\\bc\rd\nef\t\u{00A7}_\u{0F63}",
+        "0": " 0 ",
+        "1.2.3": "4.5.6",
+        " foo ": " bar ",
     }
 });
 

--- a/tests/assets/snbt_edge_cases.snbt
+++ b/tests/assets/snbt_edge_cases.snbt
@@ -29,5 +29,8 @@
     'quoted "key\"': "quoted 'value'",
     "redundant": "quotes",
     'more_redundant': 'quotes',
-    "escape sequences": "\'a\\bc\rd\nef\t\u00A7_\u0F63"
+    "escape sequences": "\'a\\bc\rd\nef\t\u00A7_\u0F63",
+    "0": " 0 ",
+    "1.2.3": "4.5.6",
+    " foo ": " bar "
 }


### PR DESCRIPTION
SNBT strings and keys that start with a number (or that start or end with whitespace) need to be quoted to preserve their value and type. Currently, if you run this library's SNBT output back into it's own SNBT parser:

- Strings like `"0"` are converted to integers.
- Strings like `"1.2.3"` cause an error. 
- Strings like `" foo "` have their leading and trailing whitespace stripped.
- Keys like `"0"` or `"1.2.3"` cause an error.
- Keys like `" foo "` have their leading and trailing whitespace stripped.

I encountered this problem while formatting a `level.dat` file as SNBT and parsing the output—version strings like `"1.19.4"` caused parse errors, and the values of game rules like `randomTickSpeed: "3"` were incorrectly converted from strings to integers.

This PR fixes these issues.