### PR TITLE
Fix SNBT generating nothing for empty string values

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -187,6 +187,10 @@ impl NbtTag {
     /// non-standard characters.
     #[inline]
     pub fn should_quote(string: &str) -> bool {
+        if string.is_empty() {
+            return true;
+        }
+
         if let Some(first) = string.chars().next() {
             if first.is_whitespace() || first.is_ascii_digit() || first == '-' {
                 return true;

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -69,3 +69,14 @@ fn number_like_strings() {
     assert_round_trip_same(compound! { "str": "0.5" });
     assert_round_trip_same(compound! { "str": "-0.5" });
 }
+
+#[test]
+fn empty_string_value() {
+    let tag = compound! { "key": "" };
+    let repr = tag.to_string();
+
+    // For manual inspection
+    println!("{repr}");
+
+    assert_eq!(quartz_nbt::snbt::parse(&repr).unwrap(), tag);
+}


### PR DESCRIPTION
Prior to this fix,
```rs
quartz_nbt::snbt::parse(&quartz_nbt::compound!{"abc":""}.to_string())
``` 
would give
```rs
Err(UnexpectedToken { index: 5, expected: "value" })
```

This fix simply edits the `should_quote` function to return true if the string is empty.
This pull request also includes a test for that so that it does not break in the future. 